### PR TITLE
Remove conda variable requirements

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,10 @@ description: 'Test a conda environment of a specific python version against all 
 inputs:
   conda_env_url:
     description: 'URL to download the conda-packd environment, e.g: https://zenodo.org/records/14862443/files/2025-1.0-py311-tiled.tar.gz'
-    required: true
+    required: false
   conda_env_md5:
     description: 'MD5 checksum of the conda environment'
-    required: true
+    required: false
   org:
     required: true
     description: 'beamline github org'


### PR DESCRIPTION
Removes the required `conda_env_url` and `conda_env_md5`. This prevents the conda environment from being downloaded twice when it is cached in the `test-beamline-profiles` repository. With these two variables as optional parameters if the cache happens to fail the url and md5 can be passed later on to be downloaded.