### PR TITLE
Adds Caching for Conda Envs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ runs:
       shell: bash -leo pipefail {0}
       run: |
         echo "::group::Parsing conda version"
-        conda_env_version=$(echo "${{ inputs.conda_env_url }}" | rev | cut -d '/' -f 1 | rev | sed "s/\.tar\.gz//g" )
+        conda_env_version=$(echo "${{ inputs.conda_env_url }}" | sed -E 's|^.*/||; s|\.tar\.gz$||' )
         echo "CONDA_ENV_VERSION=${conda_env_version}" >> $GITHUB_ENV
         echo "::endgroup::"
 

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ runs:
       uses: actions/cache@v4
       with: 
         path: ~/download_conda_env
-        key: ${{ runner.os }}-${{ hashFiles('env.tar.gz') }}
+        key: ${{ runner.os }}-${{ hashFiles('~/download_conda_env/env.tar.gz') }}
 
     - name: Download and Cache Conda env from Zenodo
       if: steps.cache-conda.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -132,22 +132,35 @@ runs:
         python-version: "3.10"
         conda-remove-defaults: true
 
-    - name: Create a conda env from Zenodo
-      shell: bash -leo pipefail {0}
+    - name: Cache Conda Environment
+      id : cache-conda
+      uses: actions/cache@v4
+      with: 
+        path: ~/download_conda_env
+        key: ${{ runner.os }}-${{ hashFiles('env.tar.gz') }}
+
+    - name: Download and Cache Conda env from Zenodo
+      if: steps.cache-conda.outputs.cache-hit == 'true'
       run: |
-        echo "::group::Downloading and setting up conda environment"
+        echo "::group::Downloading and caching conda environment"
         url="${{ inputs.conda_env_url }}?download=1"
-        wget --progress=dot:giga ${url} -O env.tar.gz
+        mkdir -p ~/download_conda_env
+        wget --progress=dot:giga ${url} -O ~/download_conda_env/env.tar.gz
         status=$?
         if [ $status -gt 0 ]; then
             echo "Cannot download from ${url}. Exit code: ${status}"
             exit $status
         fi
-        echo "${{ inputs.conda_env_md5 }} env.tar.gz" > checksum.txt
+        echo "::endgroup::"
+
+    - name: Create a conda env from downloaded file or cache
+      shell: bash -leo pipefail {0}
+      run: |
+        echo "${{ inputs.conda_env_md5 }} ~/download_conda_env/env.tar.gz" > checksum.txt
         md5sum --check checksum.txt
         mkdir -p $HOME/env
         echo "Unarchiving the tarball..."
-        tar -xf env.tar.gz -C $HOME/env
+        tar -xf ~/download_conda_env/env.tar.gz -C $HOME/env
         conda activate $HOME/env
         conda-unpack
         # TODO: release in conda-forge and add it to the standard conda env:

--- a/action.yml
+++ b/action.yml
@@ -141,6 +141,7 @@ runs:
 
     - name: Download and Cache Conda env from Zenodo
       if: steps.cache-conda.outputs.cache-hit == 'true'
+      shell: bash -leo pipefail {0}
       run: |
         echo "::group::Downloading and caching conda environment"
         url="${{ inputs.conda_env_url }}?download=1"

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         echo "::group::Downloading and caching conda environment"
         url="${{ inputs.conda_env_url }}?download=1"
         mkdir -p ~/download_conda_env
-        wget --progress=dot:giga ${url} -O ~/download_conda_env/env.tar.gz
+        time wget --progress=dot:giga ${url} -O ~/download_conda_env/env.tar.gz
         status=$?
         if [ $status -gt 0 ]; then
             echo "Cannot download from ${url}. Exit code: ${status}"

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,7 @@ runs:
     - name: Create a conda env from downloaded file or cache
       shell: bash -leo pipefail {0}
       run: |
-        echo "${{ inputs.conda_env_md5 }} ~/download_conda_env/env.tar.gz" > checksum.txt
+        echo "${{ inputs.conda_env_md5 }} $HOME/download_conda_env/env.tar.gz" > checksum.txt
         md5sum --check checksum.txt
         mkdir -p $HOME/env
         echo "Unarchiving the tarball..."

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ runs:
       uses: actions/cache@v4
       with: 
         path: ~/download_conda_env
-        key: ${{ runner.os }}-${{ hashFiles('~/download_conda_env/env.tar.gz') }}
+        key: ${{ runner.os }}-${{ inputs.conda_env_md5 }}
 
     - name: Download and Cache Conda env from Zenodo
       if: steps.cache-conda.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -132,12 +132,21 @@ runs:
         python-version: "3.10"
         conda-remove-defaults: true
 
+    - name: Parse Conda Environment Version
+      id: parse-conda-env-version
+      shell: bash -leo pipefail {0}
+      run: |
+        echo "::group::Parsing conda version"
+        conda_env_version=$(echo "${{ inputs.conda_env_url }}" | rev | cut -d '/' -f 1 | rev | sed "s/\.tar\.gz//g" )
+        echo "CONDA_ENV_VERSION=${conda_env_version}" >> $GITHUB_ENV
+        echo "::endgroup::"
+
     - name: Cache Conda Environment
       id : cache-conda
       uses: actions/cache@v4
       with: 
         path: ~/download_conda_env
-        key: ${{ runner.os }}-${{ inputs.conda_env_md5 }}
+        key: ${{ runner.os }}-${{ env.CONDA_ENV_VERSION }}-${{ inputs.conda_env_md5 }}
 
     - name: Download and Cache Conda env from Zenodo
       if: steps.cache-conda.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
         key: ${{ runner.os }}-${{ hashFiles('env.tar.gz') }}
 
     - name: Download and Cache Conda env from Zenodo
-      if: steps.cache-conda.outputs.cache-hit == 'true'
+      if: steps.cache-conda.outputs.cache-hit != 'true'
       shell: bash -leo pipefail {0}
       run: |
         echo "::group::Downloading and caching conda environment"


### PR DESCRIPTION
Uses https://github.com/actions/cache to cache conda environment. We use the key to specify the environment to be cached. The key consists of operating system, conda env version ( ex: `2025-1.0-py311-tiled`) and md5 checksum of the tarball from zenodo.

![Screenshot 2025-03-18 at 3 47 29 PM](https://github.com/user-attachments/assets/fb429a0f-f16e-424d-ba6a-f6099937f584)
https://github.com/jennmald/test-beamline-profiles/actions/caches