### PR TITLE
Apply auto settings based on beamline specific configuration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,6 +167,22 @@ runs:
         sudo ln -svf caproto-repeater "/bin/caRepeater"
         echo "::endgroup::"
 
+    - name: Apply auto settings
+      shell: bash -leo pipefail {0}
+      run: |
+        echo "::group::Applying auto settings"
+        if [ -f "${CLONNED_REPO}/.ci/auto_settings.sav" ]; then
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+                echo "Applying $line"
+                caput $line
+            fi
+          done < "${CLONNED_REPO}/.ci/auto_settings.sav"
+        else
+          echo "No auto settings script found in ${CLONNED_REPO}/.ci/auto_settings.sh"
+        fi
+        echo "::endgroup::"
+
     - uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: test-env

--- a/action.yml
+++ b/action.yml
@@ -376,7 +376,7 @@ runs:
           while IFS= read -r line; do
             if [ -n "$line" ]; then
                 echo "Applying $line"
-                caput $line
+                caproto-put $line
             fi
           done < "${CLONED_REPO}/.ci/auto_settings.sav"
         else

--- a/action.yml
+++ b/action.yml
@@ -171,15 +171,15 @@ runs:
       shell: bash -leo pipefail {0}
       run: |
         echo "::group::Applying auto settings"
-        if [ -f "${CLONNED_REPO}/.ci/auto_settings.sav" ]; then
+        if [ -f "${CLONED_REPO}/.ci/auto_settings.sav" ]; then
           while IFS= read -r line; do
             if [ -n "$line" ]; then
                 echo "Applying $line"
                 caput $line
             fi
-          done < "${CLONNED_REPO}/.ci/auto_settings.sav"
+          done < "${CLONED_REPO}/.ci/auto_settings.sav"
         else
-          echo "No auto settings script found in ${CLONNED_REPO}/.ci/auto_settings.sh"
+          echo "No auto settings script found in ${CLONED_REPO}/.ci/auto_settings.sav"
         fi
         echo "::endgroup::"
 

--- a/action.yml
+++ b/action.yml
@@ -167,22 +167,6 @@ runs:
         sudo ln -svf caproto-repeater "/bin/caRepeater"
         echo "::endgroup::"
 
-    - name: Apply auto settings
-      shell: bash -leo pipefail {0}
-      run: |
-        echo "::group::Applying auto settings"
-        if [ -f "${CLONED_REPO}/.ci/auto_settings.sav" ]; then
-          while IFS= read -r line; do
-            if [ -n "$line" ]; then
-                echo "Applying $line"
-                caput $line
-            fi
-          done < "${CLONED_REPO}/.ci/auto_settings.sav"
-        else
-          echo "No auto settings script found in ${CLONED_REPO}/.ci/auto_settings.sav"
-        fi
-        echo "::endgroup::"
-
     - uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: test-env
@@ -372,6 +356,22 @@ runs:
         client.create_container(tla).create_container('raw', specs=['CatalogOfBluesklyRuns'])
         print(client[tla]['raw'])"
         python3 -c "$command"
+        echo "::endgroup::"
+
+    - name: Apply auto settings
+      shell: bash -leo pipefail {0}
+      run: |
+        echo "::group::Applying auto settings"
+        if [ -f "${CLONED_REPO}/.ci/auto_settings.sav" ]; then
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+                echo "Applying $line"
+                caput $line
+            fi
+          done < "${CLONED_REPO}/.ci/auto_settings.sav"
+        else
+          echo "No auto settings script found in ${CLONED_REPO}/.ci/auto_settings.sav"
+        fi
         echo "::endgroup::"
 
     - name: Activate IPython profile and run tests


### PR DESCRIPTION
Adds the ability to set custom PVs immediately after starting the blackhole IOC. This is useful for any default values that need to be set prior to running the startup scripts.