### PR TITLE
Use the `spoof-beamline.py` vendored script from the action repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ runs:
   using: 'composite'
 
   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Env vars for locally cloned repo
       if: inputs.branch != ''
       shell: bash -leo pipefail {0}
@@ -162,7 +165,7 @@ runs:
       run: |
         echo "::group::Setting up Blackhole IOC"
         python3 -m pip install -U caproto
-        echo "\n" | python3 spoof_beamline.py &
+        echo "\n" | python3 ${{ github.action_path }}/spoof_beamline.py &
         trap 'kill -SIGINT %1; echo exiting...' EXIT
         sudo ln -svf caproto-repeater "/bin/caRepeater"
         echo "::endgroup::"

--- a/spoof_beamline.py
+++ b/spoof_beamline.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+import re
+from collections import defaultdict
+
+from caproto import (ChannelChar, ChannelData, ChannelDouble, ChannelEnum,
+                     ChannelInteger, ChannelString)
+from caproto.server import ioc_arg_parser, PVGroup, run
+
+PLUGIN_TYPE_PVS = [
+    (re.compile('image\\d:'), 'NDPluginStdArrays'),
+    (re.compile('Stats\\d:'), 'NDPluginStats'),
+    (re.compile('CC\\d:'), 'NDPluginColorConvert'),
+    (re.compile('Proc\\d:'), 'NDPluginProcess'),
+    (re.compile('Over\\d:'), 'NDPluginOverlay'),
+    (re.compile('ROI\\d:'), 'NDPluginROI'),
+    (re.compile('Trans\\d:'), 'NDPluginTransform'),
+    (re.compile('netCDF\\d:'), 'NDFileNetCDF'),
+    (re.compile('TIFF\\d:'), 'NDFileTIFF'),
+    (re.compile('JPEG\\d:'), 'NDFileJPEG'),
+    (re.compile('Nexus\\d:'), 'NDPluginNexus'),
+    (re.compile('HDF\\d:'), 'NDFileHDF5'),
+    (re.compile('Magick\\d:'), 'NDFileMagick'),
+    (re.compile('TIFF\\d:'), 'NDFileTIFF'),
+    (re.compile('HDF\\d:'), 'NDFileHDF5'),
+    (re.compile('Current\\d:'), 'NDPluginStats'),
+    (re.compile('SumAll'), 'NDPluginStats'),
+]
+
+
+class ReallyDefaultDict(defaultdict):
+    def __contains__(self, key):
+        return True
+
+    def __missing__(self, key):
+        if (key.endswith('-SP') or key.endswith('-I') or
+                key.endswith('-RB') or key.endswith('-Cmd')):
+            key, *_ = key.rpartition('-')
+            return self[key]
+        if key.endswith('_RBV') or key.endswith(':RBV'):
+            return self[key[:-4]]
+        ret = self[key] = self.default_factory(key)
+        return ret
+
+class BlackholeIOC(PVGroup):
+    """
+    IOC that spoofs a beamline.
+
+    You can set up SubGroups for beamline components that interact with each other.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(prefix="", *args, **kwargs)
+        # Copy the original pvdb so we can use it for channels
+        self.old_pvdb = self.pvdb.copy()
+        # Reset the pvdb to use our fabricate_channel function
+        self.pvdb = ReallyDefaultDict(self.fabricate_channel)
+
+    def fabricate_channel(self, key):
+        # Use existing channels if they exist
+        if key in self.old_pvdb:
+            return self.old_pvdb[key]
+        if 'PluginType' in key:
+            for pattern, val in PLUGIN_TYPE_PVS:
+                if pattern.search(key):
+                    return ChannelString(value=val)
+        elif 'ArrayPort' in key:
+            return ChannelString(value=key)
+        elif 'PortName' in key:
+            return ChannelString(value=key)
+        elif 'EnableCallbacks' in key:
+            return ChannelEnum(value=0, enum_strings=['Disabled', 'Enabled'])
+        elif 'BlockingCallbacks' in key:
+            return ChannelEnum(value=0, enum_strings=['No', 'Yes'])
+        elif 'Auto' in key:
+            return ChannelEnum(value=0, enum_strings=['No', 'Yes'])
+        elif 'ImageMode' in key:
+            return ChannelEnum(value=0, enum_strings=['Single', 'Multiple', 'Continuous'])
+        elif 'WriteMode' in key:
+            return ChannelEnum(value=0, enum_strings=['Single', 'Capture', 'Stream'])
+        elif 'ArraySize' in key:
+            return ChannelData(value=10)
+        elif 'TriggerMode' in key:
+            return ChannelEnum(value=0, enum_strings=['Internal', 'External'])
+        elif 'FileWriteMode' in key:
+            return ChannelEnum(value=0, enum_strings=['Single'])
+        elif 'FilePathExists' in key:
+            return ChannelData(value=1)
+        elif 'WaitForPlugins' in key:
+            return ChannelEnum(value=0, enum_strings=['No', 'Yes'])
+        elif ('file' in key.lower() and 'number' not in key.lower() and
+            'mode' not in key.lower()):
+            return ChannelChar(value='a' * 250)
+        elif ('filenumber' in key.lower()):
+            return ChannelInteger(value=0)
+        elif 'Compression' in key:
+            return ChannelEnum(value=0, enum_strings=['None', 'N-bit', 'szip', 'zlib', 'blosc'])
+        elif key.endswith(".EGU"):
+            return ChannelString(value="mm")
+        return ChannelDouble(value=0.0)
+
+
+def main():
+    print('''
+*** WARNING ***
+This script spawns an EPICS IOC which responds to ALL caget, caput, camonitor
+requests.  As this is effectively a PV black hole, it may affect the
+performance and functionality of other IOCs on your network.
+
+The script ignores the --interfaces command line argument, always
+binding only to 127.0.0.1, superseding the usual default (0.0.0.0) and any
+user-provided value.
+*** WARNING ***
+
+Press return if you have acknowledged the above, or Ctrl-C to quit.''')
+
+    try:
+        input()
+    except KeyboardInterrupt:
+        print()
+        return
+    print('''
+
+                         PV blackhole started
+
+''')
+    _, run_options = ioc_arg_parser(
+        default_prefix='',
+        desc="PV black hole")
+    run_options['interfaces'] = ['127.0.0.1']
+    run(BlackholeIOC().pvdb,
+        **run_options)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR uses the vendored `spoof-beamline.py` IOC via this action repo (no need to have it in each individual target test repo).

Test run: https://github.com/NSLS2/test-beamline-profiles/actions/runs/14082492161/job/39438440280?pr=9.

Thanks to this SO post: https://stackoverflow.com/a/72777782/4143531 ([example](https://github.com/GuillaumeFalourd/convert-json-to-env/blob/c46b414e45d29d05fe7deeac42a8070a07ffbf57/action.yml#L22C20-L22C45)).

Closes #10.